### PR TITLE
`hmm` (Haxe Module Manager)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 export/*
 .vscode/*
+.haxelib/*

--- a/hmm.json
+++ b/hmm.json
@@ -1,0 +1,39 @@
+{
+  "dependencies": [
+    {
+      "name": "flixel",
+      "type": "haxelib",
+      "version": null
+    },
+    {
+      "name": "flixel-addons",
+      "type": "haxelib",
+      "version": null
+    },
+    {
+      "name": "flixel-ui",
+      "type": "haxelib",
+      "version": null
+    },
+    {
+      "name": "hscript",
+      "type": "haxelib",
+      "version": null
+    },
+    {
+      "name": "hxcpp",
+      "type": "haxelib",
+      "version": null
+    },
+    {
+      "name": "lime",
+      "type": "haxelib",
+      "version": null
+    },
+    {
+      "name": "openfl",
+      "type": "haxelib",
+      "version": null
+    }
+  ]
+}


### PR DESCRIPTION
Tiny addition, adds [`hmm`](https://github.com/andywhite37/hmm) to make libraries installing easier.

The README goes into great detail on how to install it, add dependencies to `hmm.json`, how to update said dependencies, etc. etc. **You can read that [here](https://github.com/andywhite37/hmm/blob/master/README.md)**.